### PR TITLE
Merkle tree recursive batch

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -46,7 +46,7 @@ jobs:
             # Extract example name without path and extension
             example=$(basename "$file" .rs)
             echo "Running example: $example"
-            if [ "$example" = "merkle_tree" ] || [ "$example" = "merkle_tree_average" ] || [ "$example" = "merkle_tree_batch" ] || [ "$example" = "merkle_tree_recursive_verify" ]; then
+            if [ "$example" = "merkle_tree" ] || [ "$example" = "merkle_tree_average" ] || [ "$example" = "merkle_tree_batch" ] || [ "$example" = "merkle_tree_recursive_verify" ] || [ "$example" = "merkle_tree_recursive_batch" ]; then
               cargo run --release --example "$example" -- 2
             else
               cargo run --release --example "$example" -- -vv

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
-/examples/merkle_tree_recursive_batch.rs
 /benchmarks/results

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+/examples/recursion/merkle_tree_recursive_pairwise.rs
 /benchmarks/results

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 [[example]]
 name = "merkle_tree_recursive_verify"
 path = "examples/recursion/merkle_tree_recursive_verify.rs"
+
+[[example]]
+name = "merkle_tree_recursive_batch"
+path = "examples/recursion/merkle_tree_recursive_batch.rs"

--- a/benchmarks/scripts/merkle_tree/bench_merkle.py
+++ b/benchmarks/scripts/merkle_tree/bench_merkle.py
@@ -148,7 +148,7 @@ class MerkleTreeBenchmark:
 def main():
     parser = argparse.ArgumentParser(description='Run Merkle tree benchmarks')
     parser.add_argument('--leaf-counts', type=int, nargs='+', help='Leaf counts to benchmark')
-    parser.add_argument('--example', type=str, choices=['merkle_tree', 'merkle_tree_average', 'merkle_tree_recursive_verify'], 
+    parser.add_argument('--example', type=str, choices=['merkle_tree', 'merkle_tree_average', 'merkle_tree_recursive_verify', 'merkle_tree_recursive_batch'], 
                         default='merkle_tree', help='Which example to benchmark')
     args = parser.parse_args()
 

--- a/examples/merkle_tree_batch.rs
+++ b/examples/merkle_tree_batch.rs
@@ -121,9 +121,6 @@ fn main() -> Result<()> {
                 &proof_t,
             );
         }
-        //let build_time = now.elapsed();
-        //batch_build_times.push(build_time);
-        //println!("Batch circuit build time: {:?}", build_time);
 
         let gates = builder.num_gates();
         println!("Batch circuit gates: {}", gates);

--- a/examples/recursion/merkle_tree_recursive_batch.rs
+++ b/examples/recursion/merkle_tree_recursive_batch.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use plonky2::field::types::Field;
-use plonky2::hash::merkle_tree::MerkleTree;
 use plonky2::hash::merkle_proofs::MerkleProofTarget;
+use plonky2::hash::merkle_tree::MerkleTree;
 use plonky2::iop::witness::{PartialWitness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::circuit_data::{CircuitConfig, CircuitData};
@@ -56,7 +56,7 @@ fn build_base_circuit(
     indices: &[usize],
     proofs: &[plonky2::hash::merkle_proofs::MerkleProof<F, <C as GenericConfig<D>>::Hasher>],
     log_n: usize,
-) -> Result<(CircuitData<F, C, D>, ProofWithPublicInputs<F, C, D>,)> {
+) -> Result<(CircuitData<F, C, D>, ProofWithPublicInputs<F, C, D>)> {
     println!("Building base circuit for {} proofs...", indices.len());
 
     let config = get_circuit_config();
@@ -132,7 +132,6 @@ fn build_recursive_circuit(
     proofs: &[plonky2::hash::merkle_proofs::MerkleProof<F, <C as GenericConfig<D>>::Hasher>],
     log_n: usize,
 ) -> Result<(CircuitData<F, C, D>, ProofWithPublicInputs<F, C, D>)> {
-
     let config = get_circuit_config();
     let mut builder = CircuitBuilder::<F, D>::new(config);
     let mut pw = PartialWitness::new();
@@ -197,7 +196,6 @@ fn build_recursive_circuit(
         "Memory used for recursive proof generation: {}",
         format_size(memory_used)
     );
-
 
     Ok((data, snark_proof))
 }
@@ -315,7 +313,6 @@ fn main() -> Result<()> {
         "Memory used for proof generation: {}",
         format_size(get_peak_memory())
     );
-
 
     // Verify final proof
     println!("\nVerifying final proof...");

--- a/examples/recursion/merkle_tree_recursive_batch.rs
+++ b/examples/recursion/merkle_tree_recursive_batch.rs
@@ -1,0 +1,255 @@
+use anyhow::Result;
+use plonky2::field::types::{Field, Sample};
+use plonky2::hash::merkle_tree::MerkleTree;
+use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+use plonky2::plonk::circuit_builder::CircuitBuilder;
+use plonky2::plonk::circuit_data::{CircuitConfig, VerifierCircuitTarget};
+use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+use plonky2::plonk::proof::ProofWithPublicInputs;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use std::time::Instant;
+
+// Import utils from parent directory
+#[path = "../utils/mod.rs"]
+mod utils;
+use utils::data::build_merkle_tree;
+use utils::metrics::{format_size, measure_memory_usage};
+
+const D: usize = 2;
+const LEAF_SIZE: usize = 4;
+const TREE_SIZE: usize = 1 << 20; // Fixed size: 2^20 leaves
+const PROOFS_PER_BATCH: usize = 10; // Number of proofs to verify in each recursive step
+type C = PoseidonGoldilocksConfig;
+type F = <C as GenericConfig<D>>::F;
+
+fn build_base_circuit(
+    tree: &MerkleTree<F, <C as GenericConfig<D>>::Hasher>,
+    indices: &[usize],
+    proofs: &[plonky2::hash::merkle_proofs::MerkleProof<F, <C as GenericConfig<D>>::Hasher>],
+    log_n: usize,
+) -> Result<(
+    plonky2::plonk::circuit_data::CircuitData<F, C, D>,
+    ProofWithPublicInputs<F, C, D>,
+)> {
+    println!("Building base circuit for {} proofs...", indices.len());
+    let now = Instant::now();
+
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let mut pw = PartialWitness::new();
+
+    // Process each proof in the batch
+    for (&index, proof) in indices.iter().zip(proofs.iter()) {
+        // Add leaf data and index
+        let i_c = builder.constant(F::from_canonical_usize(index));
+        let i_bits = builder.split_le(i_c, log_n);
+
+        let data = builder.add_virtual_targets(LEAF_SIZE);
+        for (i, &value) in tree.leaves[index].iter().enumerate() {
+            pw.set_target(data[i], value);
+        }
+
+        // Add Merkle root as public input
+        let merkle_root = builder.add_virtual_hash();
+        builder.register_public_inputs(&merkle_root.elements);
+        pw.set_hash_target(merkle_root, tree.cap.0[0]);
+
+        // Add proof siblings
+        let proof_t = plonky2::hash::merkle_proofs::MerkleProofTarget {
+            siblings: builder.add_virtual_hashes(proof.siblings.len()),
+        };
+        for (i, sibling) in proof.siblings.iter().enumerate() {
+            pw.set_hash_target(proof_t.siblings[i], *sibling);
+        }
+
+        // Verify Merkle proof
+        builder.verify_merkle_proof::<<C as GenericConfig<D>>::InnerHasher>(
+            data.to_vec(),
+            &i_bits,
+            merkle_root,
+            &proof_t,
+        );
+    }
+
+    let num_gates = builder.num_gates();
+    let data = builder.build::<C>();
+    let proof = data.prove(pw)?;
+
+    println!("Base circuit build time: {:?}", now.elapsed());
+    println!("Base circuit gates: {}", num_gates);
+
+    Ok((data, proof))
+}
+
+fn build_recursive_circuit(
+    prev_data: &plonky2::plonk::circuit_data::CircuitData<F, C, D>,
+    prev_proof: &ProofWithPublicInputs<F, C, D>,
+    tree: &MerkleTree<F, <C as GenericConfig<D>>::Hasher>,
+    indices: &[usize],
+    proofs: &[plonky2::hash::merkle_proofs::MerkleProof<F, <C as GenericConfig<D>>::Hasher>],
+    log_n: usize,
+) -> Result<(
+    plonky2::plonk::circuit_data::CircuitData<F, C, D>,
+    ProofWithPublicInputs<F, C, D>,
+)> {
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let mut pw = PartialWitness::new();
+
+    // First, verify the previous proof recursively
+    let vd_target = VerifierCircuitTarget {
+        constants_sigmas_cap: builder
+            .add_virtual_cap(prev_data.common.config.fri_config.cap_height),
+        circuit_digest: builder.add_virtual_hash(),
+    };
+    pw.set_cap_target(
+        &vd_target.constants_sigmas_cap,
+        &prev_data.verifier_only.constants_sigmas_cap,
+    );
+    pw.set_hash_target(
+        vd_target.circuit_digest,
+        prev_data.verifier_only.circuit_digest,
+    );
+
+    let prev_proof_t = builder.add_virtual_proof_with_pis(&prev_data.common);
+    pw.set_proof_with_pis_target(&prev_proof_t, prev_proof);
+
+    println!("Verifying previous proof in circuit...");
+    let now = Instant::now();
+    builder.verify_proof::<C>(&prev_proof_t, &vd_target, &prev_data.common);
+    println!(
+        "Previous proof circuit verification setup time: {:?}",
+        now.elapsed()
+    );
+
+    // Now verify the new batch of Merkle proofs
+    for (&index, proof) in indices.iter().zip(proofs.iter()) {
+        let i_c = builder.constant(F::from_canonical_usize(index));
+        let i_bits = builder.split_le(i_c, log_n);
+
+        let data = builder.add_virtual_targets(LEAF_SIZE);
+        for (i, &value) in tree.leaves[index].iter().enumerate() {
+            pw.set_target(data[i], value);
+        }
+
+        let merkle_root = builder.add_virtual_hash();
+        builder.register_public_inputs(&merkle_root.elements);
+        pw.set_hash_target(merkle_root, tree.cap.0[0]);
+
+        let proof_t = plonky2::hash::merkle_proofs::MerkleProofTarget {
+            siblings: builder.add_virtual_hashes(proof.siblings.len()),
+        };
+        for (i, sibling) in proof.siblings.iter().enumerate() {
+            pw.set_hash_target(proof_t.siblings[i], *sibling);
+        }
+
+        builder.verify_merkle_proof::<<C as GenericConfig<D>>::InnerHasher>(
+            data.to_vec(),
+            &i_bits,
+            merkle_root,
+            &proof_t,
+        );
+    }
+
+    let num_gates = builder.num_gates();
+    let data = builder.build::<C>();
+    let proof = data.prove(pw)?;
+
+    println!("Recursive circuit gates: {}", num_gates);
+
+    Ok((data, proof))
+}
+
+fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Usage: {} <num_proofs>", args[0]);
+        std::process::exit(1);
+    }
+
+    let num_proofs: usize = args[1].parse().unwrap();
+    if num_proofs > TREE_SIZE {
+        eprintln!(
+            "Error: number of proofs ({}) cannot exceed tree size ({})",
+            num_proofs, TREE_SIZE
+        );
+        std::process::exit(1);
+    }
+
+    let (tree, _) = build_merkle_tree::<F, C>(TREE_SIZE, LEAF_SIZE, 0);
+    println!("Merkle Root (cap = 0): {:?}", tree.cap);
+
+    // Generate random indices and proofs
+    let mut indices: Vec<usize> = (0..leaves_len).collect();
+    indices.shuffle(&mut rng);
+    let random_indices: Vec<usize> = indices.into_iter().take(100).collect();
+
+    println!("Generating proofs for 100 leaves...");
+    let now = Instant::now();
+    let proofs: Vec<_> = random_indices.iter().map(|&i| tree.prove(i)).collect();
+    println!("Proof generation time: {:?}", now.elapsed());
+
+    let log_n = (leaves_len as f64).log2() as usize;
+
+    // Process proofs in batches
+    let mut current_data;
+    let mut current_proof;
+
+    // Build base circuit with first batch
+    let first_batch_size = random_indices.len().min(PROOFS_PER_BATCH);
+    (current_data, current_proof) = build_base_circuit(
+        &tree,
+        &random_indices[0..first_batch_size],
+        &proofs[0..first_batch_size],
+        log_n,
+    )?;
+
+    // Build recursive circuits for remaining batches
+    let mut total_build_time = std::time::Duration::new(0, 0);
+    let remaining_proofs = random_indices.len() - first_batch_size;
+    let num_batches = remaining_proofs.div_ceil(PROOFS_PER_BATCH);
+
+    for i in 0..num_batches {
+        let start_idx = first_batch_size + i * PROOFS_PER_BATCH;
+        let end_idx = (start_idx + PROOFS_PER_BATCH).min(random_indices.len());
+
+        println!(
+            "Building recursive circuit for batch {}/{}...",
+            i + 1,
+            num_batches
+        );
+        let now = Instant::now();
+
+        let (new_data, new_proof) = build_recursive_circuit(
+            &current_data,
+            &current_proof,
+            &tree,
+            &random_indices[start_idx..end_idx],
+            &proofs[start_idx..end_idx],
+            log_n,
+        )?;
+
+        let elapsed = now.elapsed();
+        total_build_time += elapsed;
+        println!("Recursive circuit {} build time: {:?}", i + 1, elapsed);
+
+        current_data = new_data;
+        current_proof = new_proof;
+    }
+
+    if num_batches > 0 {
+        println!(
+            "Average recursive circuit build time: {:?}",
+            total_build_time / (num_batches as u32)
+        );
+    }
+
+    // Verify final proof
+    println!("Verifying final proof...");
+    let now = Instant::now();
+    current_data.verify(current_proof)?;
+    println!("Final verification time: {:?}", now.elapsed());
+
+    Ok(())
+}

--- a/examples/recursion/merkle_tree_recursive_verify.rs
+++ b/examples/recursion/merkle_tree_recursive_verify.rs
@@ -16,6 +16,7 @@ use std::time::Instant;
 // Import utils from parent directory
 #[path = "../utils/mod.rs"]
 mod utils;
+mod merkle_tree_recursive_batch;
 use utils::data::build_merkle_tree;
 use utils::metrics::{format_size, measure_memory_usage};
 

--- a/examples/recursion/merkle_tree_recursive_verify.rs
+++ b/examples/recursion/merkle_tree_recursive_verify.rs
@@ -16,7 +16,6 @@ use std::time::Instant;
 // Import utils from parent directory
 #[path = "../utils/mod.rs"]
 mod utils;
-mod merkle_tree_recursive_batch;
 use utils::data::build_merkle_tree;
 use utils::metrics::{format_size, measure_memory_usage};
 


### PR DESCRIPTION
This PR adds the example `merkle_tree_recursive_batch.rs`, which allows recursive proofs with batches of leaves.